### PR TITLE
Specify db to use to create the temporal DBs

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -43,4 +43,3 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     version: 8.0.2
     condition: grafana.enabled
-

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -55,7 +55,7 @@ spec:
               {{- if eq $driver "cassandra" }}
           command: ['temporal-cassandra-tool', 'create', '-k', '{{ $storeConfig.cassandra.keyspace }}', '--replication-factor', '{{ $storeConfig.cassandra.replicationFactor }}']
               {{- else if eq $driver "sql" }}
-          command: ['temporal-sql-tool', 'create-database']
+          command: ['temporal-sql-tool', 'create-database', '--defaultdb','{{ $storeConfig.sql.defaultdb }}']
               {{- end }}
           env:
               {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -153,9 +153,11 @@ server:
               consistency: "local_quorum"
               serialConsistency: "local_serial"
         sql:
-          driver: "mysql"
-          host: "mysql"
-          port: 3306
+          driver: "postgres12"
+          host: "postgres"
+          port: 5432
+          # database used to connect to so the temporal database can be created
+          defaultdb: "postgres"
           database: "temporal"
           user: "temporal"
           password: "temporal"
@@ -186,6 +188,7 @@ server:
           driver: "mysql"
           host: "mysql"
           port: 3306
+          defaultdb: "postgres"
           database: "temporal_visibility"
           user: "temporal"
           password: "temporal"

--- a/charts/temporal/values/values.postgresql.yaml
+++ b/charts/temporal/values/values.postgresql.yaml
@@ -8,6 +8,8 @@ server:
           driver: "postgres12"
           host: _HOST_
           port: 5432
+          # database used to connect to so the temporal database can be created
+          defaultdb: postgres
           database: temporal
           user: _USER_
           password: _PASSWORD_
@@ -36,6 +38,8 @@ server:
           driver: "postgres12"
           host: _HOST_
           port: 5432
+          # database used to connect to so the visibility database can be created
+          defaultdb: postgres
           database: temporal_visibility
           user: _USER_
           password: _PASSWORD_


### PR DESCRIPTION
If you want the helm chart to create the `temporal` and `visibility` databases 
the sql tool will use `postgres` or `defaultdb` as a database to connect to.
This commit adds the ability to specify which is this default db for the sql tool
to connect to first.